### PR TITLE
Changes to widget updater coroutine

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 1
-        versionName = "0.7.0"
+        versionName = "0.7.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/widget/MissionWidgetUpdater.kt
+++ b/app/src/main/java/widget/MissionWidgetUpdater.kt
@@ -3,14 +3,16 @@ package widget
 import android.content.Context
 import api.fetchData
 import data.MissionInfoEntry
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import tools.formatMissionData
 import user.preferences.PreferencesDatastore
 import java.time.Instant
 
 class MissionWidgetUpdater {
     fun updateMissions(context: Context) {
-        runBlocking {
+        CoroutineScope(context = Dispatchers.IO).launch {
             val preferences = PreferencesDatastore(context)
             var preferencesMissionData = preferences.getMissionInfo()
 
@@ -47,7 +49,7 @@ class MissionWidgetUpdater {
                     MissionWidgetDataStore().setOpenEggInc(context, prefOpenEggInc)
                 }
             } catch (e: Exception) {
-                throw e
+                println("Error was here $e")
             }
         }
     }


### PR DESCRIPTION
Move the widget updater to a coroutine scope on the IO thread. This allows the update process to happen in the background, instead blocking everything with `runBlocking`. This means the click to open app action is more responsive.

Additionally, there should be fewer calls to the updater after moving the initial state-loading update call to only fire if eid is blank. Previously it was getting called every time the widget recomposed or was clicked, meaning there were far more updates happening than necessary.