### PR TITLE
Layout adjustments for fuel tank levels

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 1
-        versionName = "0.8.0"
+        versionName = "0.8.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/widget/large/MissionWidgetLarge.kt
+++ b/app/src/main/java/widget/large/MissionWidgetLarge.kt
@@ -335,17 +335,16 @@ fun TankInfoContent(tankInfo: TankInfo, assetManager: AssetManager) {
                     Image(
                         provider = ImageProvider(eggBitmap),
                         contentDescription = "Egg icon",
-                        modifier = GlanceModifier.size(20.dp)
+                        modifier = GlanceModifier.size(20.dp).padding(end = 5.dp)
                     )
                     LinearProgressIndicator(
-                        modifier = GlanceModifier.height(5.dp).width(100.dp)
-                            .padding(horizontal = 5.dp),
+                        modifier = GlanceModifier.height(5.dp).defaultWeight(),
                         progress = getFuelPercentFilled(capacity, fuel.fuelQuantity),
                         color = ColorProvider(color = Color(0xff6bd55f)),
                         backgroundColor = ColorProvider(color = Color(0xff464646))
                     )
                     Row(
-                        modifier = GlanceModifier.fillMaxWidth(),
+                        modifier = GlanceModifier.width(50.dp),
                         horizontalAlignment = Alignment.End
                     ) {
                         Text(


### PR DESCRIPTION
A few adjustments to make fuel tank levels stay on the same line when the fuel amount text takes up a lot of space. It was hard to get the text right aligned while also making the progress bar expand to fill the space as needed in a way that the right side of the bar lined up with one another. If I just let the text take up as much room as necessary, none of the bars are even on the right side. The solution I came up with was to give the text section a set width so that the progress bars can't expand into that section.