### PR TITLE
Contract widget

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.23" />
+    <option name="version" value="2.1.0" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.compose.compiler)
     id("com.google.protobuf")
     kotlin("plugin.serialization") version "2.0.20"
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.widgetegg.widgeteggapp"
         minSdk = 26
         targetSdk = 35
-        versionCode = 13
-        versionName = "2.0.0"
+        versionCode = 14
+        versionName = "2.0.1"
 
         ndk {
             debugSymbolLevel = "SYMBOL_TABLE"

--- a/app/src/main/java/api/Api.kt
+++ b/app/src/main/java/api/Api.kt
@@ -26,6 +26,7 @@ import io.ktor.http.contentType
 import io.ktor.util.decodeBase64Bytes
 import io.ktor.util.encodeBase64
 import tools.buildSecureAuthMessage
+import java.util.concurrent.TimeUnit
 
 suspend fun fetchActiveMissions(basicRequestInfo: BasicRequestInfo): List<MissionInfo> {
     val url = MISSION_ENDPOINT
@@ -162,7 +163,15 @@ fun getBasicRequestInfo(eid: String): BasicRequestInfo {
 }
 
 private fun createHttpClient(): HttpClient {
-    return HttpClient(OkHttp)
+    return HttpClient(OkHttp) {
+        engine {
+            config {
+                connectTimeout(20, TimeUnit.SECONDS)
+                readTimeout(20, TimeUnit.SECONDS)
+                writeTimeout(20, TimeUnit.SECONDS)
+            }
+        }
+    }
 }
 
 private suspend fun makeRequest(

--- a/app/src/main/java/com/widgetegg/widgeteggapp/main/SignInViewModel.kt
+++ b/app/src/main/java/com/widgetegg/widgeteggapp/main/SignInViewModel.kt
@@ -94,6 +94,7 @@ class SignInViewModel(application: Application) : AndroidViewModel(application) 
                 preferences.saveEiUserName(backupResult.userName)
                 preferences.saveEid(eid)
                 MissionWidgetDataStore().setEid(context, eid)
+                ContractWidgetDataStore().setEid(context, eid)
                 updateHasSubmitted(false)
                 updateEid("")
             } catch (e: Exception) {

--- a/app/src/main/java/data/Constants.kt
+++ b/app/src/main/java/data/Constants.kt
@@ -1,8 +1,9 @@
 package data
 
-const val MISSION_ENDPOINT = "https://www.auxbrain.com/ei_afx/get_active_missions"
-const val BACKUP_ENDPOINT = "https://www.auxbrain.com/ei/bot_first_contact"
-const val CONTRACT_ENDPOINT = "https://www.auxbrain.com/ei/coop_status"
+const val API_ROOT = "https://www.auxbrain.com"
+const val MISSION_ENDPOINT = "${API_ROOT}/ei_afx/get_active_missions"
+const val BACKUP_ENDPOINT = "${API_ROOT}/ei/bot_first_contact"
+const val CONTRACT_ENDPOINT = "${API_ROOT}/ei/coop_status"
 
 const val CURRENT_CLIENT_VERSION = 69
 

--- a/app/src/main/java/widget/contracts/ContractWidgetReceiver.kt
+++ b/app/src/main/java/widget/contracts/ContractWidgetReceiver.kt
@@ -31,7 +31,7 @@ open class ContractWidgetReceiver : GlanceAppWidgetReceiver() {
             .build()
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             "contract_widget_worker",
-            ExistingPeriodicWorkPolicy.KEEP,
+            ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
             workRequest
         )
     }

--- a/app/src/main/java/widget/missions/MissionWidgetReceiver.kt
+++ b/app/src/main/java/widget/missions/MissionWidgetReceiver.kt
@@ -31,7 +31,7 @@ open class MissionWidgetReceiver : GlanceAppWidgetReceiver() {
             .build()
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             "mission_widget_worker",
-            ExistingPeriodicWorkPolicy.KEEP,
+            ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
             workRequest
         )
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.compose.compiler) apply false
     id("com.google.protobuf") version "0.9.4" apply false
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,14 +2,14 @@
 agp = "8.9.2"
 datastorePreferences = "1.1.1"
 glanceAppwidget = "1.1.1"
-kotlin = "1.9.23"
+kotlin = "2.1.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 kotlinxCoroutinesAndroid = "1.8.0"
 kotlinxSerializationJson = "1.6.3"
-ktor = "2.3.12"
+ktor = "3.1.3"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.12.01"
@@ -51,4 +51,5 @@ protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 


### PR DESCRIPTION
A number of small changes here.

- Offline time now accounts for silo capacity. If a contract contributor has been offline longer than their silos allow, then offline eggs contributed will be capped to match silo time instead of total offline time.
- Update ktor library (which necessitated kotlin updating too) in an effort to make api calls more reliable. Not sure if this changed anything.
- Change the default timeout on network requests to be 20 seconds (default is 10). Some users were not getting updates to their contract widget, because the api call was taking longer than 10 seconds to respond.
- Fix a small bug where contract data does not load in a contract widget if the widget existed before you logged into the app.
- Change the periodic work type from `KEEP` to `CANCEL_AND_REENQUEUE`. This _should_ mean that if a previous work request gets stuck, it will cancel and retry. Previously it would do nothing and wait for the existing work to finish. I don't know if this was actually an issue, but I am wondering if sometimes the worker just gets stuck and can't recover.

Between the timeout and work type changes, I am hoping this makes widget updates more reliable for people.